### PR TITLE
added a Dockerfile, but is has an issue starting

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3
+
+WORKDIR /usr/src/schul_cloud_search_tests
+
+ADD requirements.txt ./
+ADD LICENSE ./
+
+RUN pip3 install -r requirements.txt
+
+ENTRYPOINT python3 -m schul_cloud_search_tests.proxy


### PR DESCRIPTION
The docker images was built successfully with `docker build .`. However when I run a container by `docker run -it IMAGE_ID`, it failed with 
> /usr/local/bin/python3: Error while finding module specification for 'schul_cloud_search_tests.proxy' (ModuleNotFoundError: No module named 'schul_cloud_search_tests')

Looks like python3 can't locate the installed module. When I tried locally to install the module, this issue didn't show up.

I'm not very familiar with python modules, but I'm still looking into this issue and hopefully can resolve it. Any comments or suggestions are welcome. 

Thanks.